### PR TITLE
Dev/feat/user detail

### DIFF
--- a/app/src/main/java/com/kiki/githubsearch/domain/usecase/GetUserDetailsByUsername.kt
+++ b/app/src/main/java/com/kiki/githubsearch/domain/usecase/GetUserDetailsByUsername.kt
@@ -1,0 +1,32 @@
+package com.kiki.githubsearch.domain.usecase
+
+import com.kiki.githubsearch.data.datasources.local.entity.toDomain
+import com.kiki.githubsearch.data.datasources.remote.dto.toDomain
+import com.kiki.githubsearch.domain.DataError
+import com.kiki.githubsearch.domain.Result
+import com.kiki.githubsearch.domain.flowResult
+import com.kiki.githubsearch.domain.model.User
+import com.kiki.githubsearch.domain.model.toEntity
+import com.kiki.githubsearch.domain.repository.UserRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetUserDetailsByUsername @Inject constructor(
+    private val usersRepository: UserRepository
+) {
+    operator fun invoke(username: String): Flow<Result<User, DataError>> = flowResult {
+        try {
+            val remoteUser = usersRepository.getUserDetailsByUsername(username)
+            val domainUser = remoteUser.toDomain()
+
+            usersRepository.insertUserToLocal(domainUser.toEntity())
+
+            domainUser
+        } catch (remoteError: Throwable) {
+
+            usersRepository.getLocalUserByUsername(username)
+                ?.toDomain()
+                ?: throw remoteError
+        }
+    }
+}

--- a/app/src/main/java/com/kiki/githubsearch/domain/usecase/UsersUseCases.kt
+++ b/app/src/main/java/com/kiki/githubsearch/domain/usecase/UsersUseCases.kt
@@ -1,8 +1,10 @@
 package com.example.github_search.domain.usecases
 
+import com.kiki.githubsearch.domain.usecase.GetUserDetailsByUsername
 import com.kiki.githubsearch.domain.usecase.SearchUsers
 import javax.inject.Inject
 
 class UsersUseCases @Inject constructor(
-    val searchUsers: SearchUsers
+    val searchUsers: SearchUsers,
+    val getUserDetailsByUsername: GetUserDetailsByUsername
 )

--- a/app/src/main/java/com/kiki/githubsearch/presentation/components/CustomSearchBar.kt
+++ b/app/src/main/java/com/kiki/githubsearch/presentation/components/CustomSearchBar.kt
@@ -29,7 +29,7 @@ fun CustomSearchBar(
         onValueChange = onTextChange,
         modifier = modifier
             .fillMaxWidth()
-            .padding(8.dp),
+            .padding(horizontal = 16.dp, vertical = 8.dp),
         placeholder = { Text("Search GitHub users...") },
         trailingIcon = {
             IconButton(onClick = onSearchClicked) {

--- a/app/src/main/java/com/kiki/githubsearch/presentation/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/kiki/githubsearch/presentation/navigation/AppNavHost.kt
@@ -1,10 +1,14 @@
 package com.kiki.githubsearch.presentation.navigation
 
+import androidx.compose.compiler.plugins.kotlin.EmptyFunctionMetrics
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.kiki.githubsearch.presentation.components.toolbar.ToolbarConfig
+import com.kiki.githubsearch.presentation.user.detail.UserDetailScreen
 import com.kiki.githubsearch.presentation.user.search.search.SearchScreen
 
 @Composable
@@ -18,6 +22,20 @@ fun AppNavHost(
                 onNavigateToDetail = { username ->
                     navController.navigate(Screen.UserDetails.createRoute(username))
                 },
+                updateToolbar = updateToolbar
+            )
+        }
+        composable(
+            route = Screen.UserDetails.route,
+            arguments = listOf(
+                navArgument("username") { type = NavType.StringType }
+            )
+        ) { backStackEntry ->
+
+            val username = backStackEntry.arguments?.getString("username") ?: return@composable
+
+            UserDetailScreen(
+                username = username,
                 updateToolbar = updateToolbar
             )
         }

--- a/app/src/main/java/com/kiki/githubsearch/presentation/user/detail/DetailScreen.kt
+++ b/app/src/main/java/com/kiki/githubsearch/presentation/user/detail/DetailScreen.kt
@@ -1,0 +1,78 @@
+package com.kiki.githubsearch.presentation.user.detail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.kiki.githubsearch.presentation.components.CharacterHeader
+import com.kiki.githubsearch.presentation.components.CustomPullToRefreshBox
+import com.kiki.githubsearch.presentation.components.RowTitleDesc
+import com.kiki.githubsearch.presentation.components.toolbar.ToolbarConfig
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UserDetailScreen(
+    username: String = "",
+    viewModel: DetailViewModel = hiltViewModel(),
+    updateToolbar: (ToolbarConfig) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val scrollState = rememberScrollState()
+
+    LaunchedEffect(username) {
+        viewModel.getUserDetailByUsername(username)
+        updateToolbar(ToolbarConfig(title = "Details"))
+    }
+
+    Surface (
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+    ) {
+        CustomPullToRefreshBox(
+            isRefreshing = uiState.isRefreshing,
+            onRefresh = viewModel::onPullRefresh
+        ) {
+            Column(modifier = Modifier.verticalScroll(scrollState)) {
+                CharacterHeader(
+                    imageUrl = uiState.userDetail.avatarUrl.orEmpty(),
+                    name = uiState.userDetail.name.orEmpty()
+                )
+
+                Card(
+                    elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+                    shape = RoundedCornerShape(12.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp, horizontal = 16.dp)
+                ){
+
+                    RowTitleDesc("Username", uiState.userDetail.username ?: "-")
+                    RowTitleDesc("Bio", uiState.userDetail.bio ?: "-")
+                    RowTitleDesc("Email", uiState.userDetail.email ?: "-")
+                    RowTitleDesc("Followers", uiState.userDetail.followers.toString())
+                    RowTitleDesc("Following", uiState.userDetail.following.toString())
+                    RowTitleDesc("Company", uiState.userDetail.company ?: "-")
+                    RowTitleDesc("Twitter", uiState.userDetail.twitter ?: "-")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kiki/githubsearch/presentation/user/detail/DetailUiState.kt
+++ b/app/src/main/java/com/kiki/githubsearch/presentation/user/detail/DetailUiState.kt
@@ -1,0 +1,12 @@
+package com.kiki.githubsearch.presentation.user.detail
+
+import com.kiki.githubsearch.domain.model.User
+import com.kiki.githubsearch.presentation.UiText
+
+data class DetailUiState(
+    val username: String? = null,
+    val userDetail: User = User(),
+    val isLoading: Boolean = false,
+    val errorMessage: UiText? = null,
+    val isRefreshing: Boolean = false
+)

--- a/app/src/main/java/com/kiki/githubsearch/presentation/user/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/kiki/githubsearch/presentation/user/detail/DetailViewModel.kt
@@ -1,0 +1,66 @@
+package com.kiki.githubsearch.presentation.user.detail
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.github_search.domain.usecases.UsersUseCases
+import javax.inject.Inject
+import com.kiki.githubsearch.domain.Result
+import com.kiki.githubsearch.domain.model.User
+import com.kiki.githubsearch.presentation.asUiText
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class DetailViewModel @Inject constructor(
+    private val usersUseCases: UsersUseCases
+): ViewModel() {
+
+    private var _uiState = MutableStateFlow(DetailUiState())
+    var uiState: StateFlow<DetailUiState> = _uiState
+
+    fun getUserDetailByUsername(username: String){
+        _uiState.value = _uiState.value.copy(isLoading = true, username = username)
+        viewModelScope.launch {
+            usersUseCases.getUserDetailsByUsername(_uiState.value.username.orEmpty()).collect{ result ->
+                when(result){
+                    is Result.Success -> {
+                        _uiState.value = _uiState.value.copy(
+                            isLoading = false,
+                            isRefreshing = false,
+                            userDetail = User(
+                                id = result.data.id,
+                                avatarUrl = result.data.avatarUrl,
+                                username = result.data.username,
+                                name = result.data.name,
+                                bio = result.data.bio,
+                                email = result.data.email,
+                                company = result.data.company,
+                                twitter = result.data.twitter,
+                                followers = result.data.followers,
+                                following = result.data.following
+                            )
+                        )
+                    }
+
+                    is Result.Error -> {
+                        _uiState.value = _uiState.value.copy(
+                            isLoading = false,
+                            isRefreshing = false,
+                            errorMessage = result.error.asUiText()
+                        )
+                    }
+                    Result.Loading -> {
+                        _uiState.value = _uiState.value.copy(isLoading = true)
+                    }
+                }
+            }
+        }
+    }
+
+    fun onPullRefresh(){
+        _uiState.value = _uiState.value.copy(isRefreshing = true)
+        getUserDetailByUsername(_uiState.value.username.orEmpty())
+    }
+}

--- a/app/src/main/java/com/kiki/githubsearch/presentation/user/search/search/SearchScreen.kt
+++ b/app/src/main/java/com/kiki/githubsearch/presentation/user/search/search/SearchScreen.kt
@@ -34,11 +34,11 @@ fun SearchScreen(
     viewModel: SearchViewModel = hiltViewModel(),
     modifier: Modifier = Modifier
 ) {
-    val state by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsState()
     val listState = rememberLazyListState()
 
     LaunchedEffect(Unit) {
-        updateToolbar(ToolbarConfig(title = "Search"))
+            updateToolbar(ToolbarConfig(title = "Search"))
     }
 
     LaunchedEffect(listState) {
@@ -46,8 +46,8 @@ fun SearchScreen(
             .collect { visibleItems ->
                 val lastVisibleIndex = visibleItems.lastOrNull()?.index ?: return@collect
 
-                val isAtEnd = lastVisibleIndex >= state.userList.lastIndex
-                val canLoadMore = !state.isLoading && !state.endPage
+                val isAtEnd = lastVisibleIndex >= uiState.userList.lastIndex
+                val canLoadMore = !uiState.isLoading && !uiState.endPage
 
                 if (isAtEnd && canLoadMore) {
                     viewModel.loadNextPage()
@@ -58,13 +58,13 @@ fun SearchScreen(
     Surface(modifier = modifier.fillMaxSize()) {
         Column {
             CustomSearchBar(
-                searchText = state.searchText,
+                searchText = uiState.searchText,
                 onTextChange = viewModel::onTextChanged,
                 onSearchClicked = viewModel::onSearchClicked
             )
 
             when {
-                state.isLoading && state.userList.isEmpty() -> {
+                uiState.isLoading && uiState.userList.isEmpty() -> {
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                         CircularProgressIndicator()
                     }
@@ -72,10 +72,10 @@ fun SearchScreen(
 
                 else -> {
                     CustomPullToRefreshBox(
-                        isRefreshing = state.isRefreshing,
+                        isRefreshing = uiState.isRefreshing,
                         onRefresh = viewModel::onPullRefresh
                     ) {
-                        val uniqueUsers = state.userList.distinctBy { it.id }
+                        val uniqueUsers = uiState.userList.distinctBy { it.id }
 
                         LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
                             itemsIndexed(uniqueUsers, key = { _, item -> item.id ?: 0 }) { _, user ->
@@ -89,7 +89,7 @@ fun SearchScreen(
                                 )
                             }
 
-                            if (state.isLoading) {
+                            if (uiState.isLoading) {
                                 item {
                                     Box(
                                         modifier = Modifier


### PR DESCRIPTION
## This pull request contain changes or add, on:
- [] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description:
Implement User Detail Feature to see the detail of the users after clicked the item of the list.  Add GetUserDetailsByUsername that fetch data remotely and then store in the localDb so while no Internet users still can see the previous data searched.  Users can try to pull Refresh if the data not load because bad internet connection


## Bird Eye View Changes: 
- Created GetUserDetail Screen Using Jetpack Compose

- Integrated Detail to manage search state and business logic

- Implemented getUserDetailByUsername to fetch data remote first then store to localdb

- Setup DetailSCreen in AppNavHost for navigation